### PR TITLE
decoding no longer fails when unrepresentable tag size is encountered

### DIFF
--- a/lib/ebml/decoder.js
+++ b/lib/ebml/decoder.js
@@ -115,7 +115,13 @@ EbmlDecoder.prototype.readSize = function() {
     this._total += size.length;
     this._state = STATE_CONTENT;
     tagObj.dataSize = size.value;
-    tagObj.end += size.value + size.length;
+
+    // unknown size
+    if (size.value === -1) {
+        tagObj.end = -1;
+    } else {
+        tagObj.end += size.value + size.length;
+    }
 
     debug('read size: ' + size.value);
 

--- a/lib/ebml/tools.js
+++ b/lib/ebml/tools.js
@@ -17,8 +17,10 @@ var tools = {
         for (i = 1; i < length; i++) {
             if (i === 7) {
                 if (value >= Math.pow(2, 53 - 8) && buffer[start + 7] > 0) {
-                    throw new Error("Unrepresentable value: " +
-                        buffer.toString('hex', start, start + length));
+                    return {
+                        length: length,
+                        value: -1
+                    };
                 }
             }
             value *= Math.pow(2, 8);

--- a/test/ebml.js
+++ b/test/ebml.js
@@ -56,16 +56,16 @@ describe('embl', function() {
             it('should read the correct value for the max representable JS number (2^53)', function() {
                 readVint(new Buffer([0x01, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), Math.pow(2, 53));
             });
-            it('should throw for more than max representable JS number (2^53 + 1)', function() {
-                assert.throws(function() {
-                    ebml.tools.readVint(new Buffer([0x01, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]));
-                }, /Unrepresentable value/);
-            });
-            it('should throw for more than max representable JS number (8 byte int max value)', function() {
-                assert.throws(function() {
-                    ebml.tools.readVint(new Buffer([0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]));
-                }, /Unrepresentable value/);
-            });
+            // it('should throw for more than max representable JS number (2^53 + 1)', function() {
+            //     assert.throws(function() {
+            //         ebml.tools.readVint(new Buffer([0x01, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]));
+            //     }, /Unrepresentable value/);
+            // });
+            // it('should throw for more than max representable JS number (8 byte int max value)', function() {
+            //     assert.throws(function() {
+            //         ebml.tools.readVint(new Buffer([0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]));
+            //     }, /Unrepresentable value/);
+            // });
             it('should throw for 9+ byte int values', function() {
                 assert.throws(function() {
                     ebml.tools.readVint(new Buffer([0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF]));

--- a/test/ebml.js
+++ b/test/ebml.js
@@ -56,16 +56,13 @@ describe('embl', function() {
             it('should read the correct value for the max representable JS number (2^53)', function() {
                 readVint(new Buffer([0x01, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]), Math.pow(2, 53));
             });
-            // it('should throw for more than max representable JS number (2^53 + 1)', function() {
-            //     assert.throws(function() {
-            //         ebml.tools.readVint(new Buffer([0x01, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]));
-            //     }, /Unrepresentable value/);
-            // });
-            // it('should throw for more than max representable JS number (8 byte int max value)', function() {
-            //     assert.throws(function() {
-            //         ebml.tools.readVint(new Buffer([0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]));
-            //     }, /Unrepresentable value/);
-            // });
+            // an unknown value is represented by -1
+            it('should return value -1 for more than max representable JS number (2^53 + 1)', function() {
+                readVint(new Buffer([0x01, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]), -1);
+            });
+            it('should return value -1 for more than max representable JS number (8 byte int max value)', function() {
+                readVint(new Buffer([0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]), -1);
+            });
             it('should throw for 9+ byte int values', function() {
                 assert.throws(function() {
                     ebml.tools.readVint(new Buffer([0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF]));


### PR DESCRIPTION
I'm not sure if an unknown element size is only encountered with Matroska livestreams, but this made webm livestreaming possible for me. I'd like to use node-ebml as a dependency rather than forking it. Instead of throwing an error when encountering an unrepresentable tag size, the end should be treated as unknown.

Fix to issue #8.