### PR TITLE
stream transform encoder and decoder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 0.10
-  - 0.11
+  - 0.12
+  - 4.0

--- a/lib/ebml/decoder.js
+++ b/lib/ebml/decoder.js
@@ -1,4 +1,4 @@
-var Writable = require('stream').Writable,
+var Transform = require('stream').Transform,
     tools = require('./tools.js'),
     schema = require('./schema.js'),
     debug = require('debug')('ebml:decoder');
@@ -9,10 +9,9 @@ var STATE_TAG = 1,
 
 
 function EbmlDecoder(options) {
-
-    Writable.call(this, options);
-
     options = options || {};
+    options.readableObjectMode = true;
+    Transform.call(this, options);
 
     this._buffer = null;
     this._tag_stack = [];
@@ -22,9 +21,9 @@ function EbmlDecoder(options) {
     this._schema = schema;
 }
 
-require('util').inherits(EbmlDecoder, Writable);
+require('util').inherits(EbmlDecoder, Transform);
 
-EbmlDecoder.prototype._write = function(chunk, enc, done) {
+EbmlDecoder.prototype._transform = function(chunk, enc, done) {
 
     if (this._buffer === null) {
         this._buffer = chunk;
@@ -136,7 +135,7 @@ EbmlDecoder.prototype.readContent = function() {
 
     if (tagObj.type === 'm') {
         debug('content should be tags');
-        this.emit(tagObj.name, tagObj);
+        this.push(['start', tagObj]);
         this._state = STATE_TAG;
         return true;
     }
@@ -157,14 +156,14 @@ EbmlDecoder.prototype.readContent = function() {
     this._tag_stack.pop(); // remove the object from the stack
 
     tagObj.data = data;
-    this.emit(tagObj.name, tagObj);
+    this.push(['tag', tagObj]);
 
     while (this._tag_stack.length > 0) {
         var topEle = this._tag_stack[this._tag_stack.length - 1];
         if (this._total < topEle.end) {
             break;
         }
-        this.emit(topEle.name + ':end', topEle);
+        this.push(['end', topEle]);
         this._tag_stack.pop();
     }
 

--- a/lib/ebml/encoder.js
+++ b/lib/ebml/encoder.js
@@ -1,56 +1,61 @@
-var Readable = require('stream').Readable,
+var Transform = require('stream').Transform,
     tools = require('./tools.js'),
     schema = require('./schema.js'),
     debug = require('debug')('ebml:encoder'),
     Buffers = require('buffers');
 
 function EbmlEncoder(options) {
-
-    Readable.call(this, options);
-
     options = options || {};
+    options.writableObjectMode = true;
+    Transform.call(this, options);
 
     this._schema = schema;
-    this._cursor = 0;
-    this._pending = 0;
+    this._buffer = null;
+    this._corked = false;
 
-    this._stack = [{
-            children: []
-        }];
+    this._stack = [];
 }
 
-require('util').inherits(EbmlEncoder, Readable);
+require('util').inherits(EbmlEncoder, Transform);
 
-EbmlEncoder.prototype._read = function(size) {
-    debug('read ' + size);
-    this._pending += size;
-    this._flush();
+EbmlEncoder.prototype._transform = function(chunk, enc, done) {
+    debug('encode ' + chunk[0] + ' ' + chunk[1].name);
+
+    if(chunk[0] === 'start') {
+        this.startTag(chunk[1].name);
+    } else if(chunk[0] === 'tag') {
+        this.writeTag(chunk[1].name, chunk[1].data);
+    } else if(chunk[0] === 'end') {
+        this.endTag(chunk[1].name);
+    }
+
+    done();
 };
 
-EbmlEncoder.prototype._flush = function() {
-
-    var buffer = this._stack[0].children[0] && this._stack[0].children[0].data;
-
-    if (!buffer || this._pending === 0) {
+EbmlEncoder.prototype._flush = function(done) {
+    done = done || function(){};
+    if (!this._buffer || this._corked) {
         debug('no buffer/nothing pending');
+        done();
         return;
     }
 
-    debug('writing ' + this._pending + ' bytes');
+    debug('writing ' + this._buffer.length + ' bytes');
 
-    var chunk = buffer.slice(this._cursor, this._cursor + this._pending);
-    this._cursor += this._pending;
-    this._pending = 0;
+    var chunk = this._buffer.toBuffer();
+    this._buffer = null;
     this.push(chunk);
-
-    debug('remaining buffer ' + (buffer.length - this._cursor));
-
-    if (this._cursor >= buffer.length) {
-        debug('buffer empty');
-        this.push(null);
-    }
+    done();
 };
 
+EbmlEncoder.prototype._bufferAndFlush = function(buffer) {
+    if(this._buffer) {
+        this._buffer.push(buffer);
+    } else {
+        this._buffer = Buffers([buffer]);
+    }
+    this._flush();
+};
 
 EbmlEncoder.prototype.getSchemaInfo = function(tagName) {
     var tagStrs = Object.keys(this._schema);
@@ -63,6 +68,15 @@ EbmlEncoder.prototype.getSchemaInfo = function(tagName) {
     return null;
 };
 
+EbmlEncoder.prototype.cork = function() {
+    this._corked = true;
+};
+
+EbmlEncoder.prototype.uncork = function() {
+    this._corked = false;
+    this._flush();
+};
+
 EbmlEncoder.prototype._encodeTag = function(tagId, tagData) {
     return Buffers([tagId, tools.writeVint(tagData.length), tagData]);
 };
@@ -73,11 +87,14 @@ EbmlEncoder.prototype.writeTag = function(tagName, tagData) {
         throw new Error('No schema entry found for ' + tagName);
     }
 
-    this._stack[this._stack.length - 1].children.push({
-        data: this._encodeTag(tagId, tagData)
-    });
-
-    this._flush();
+    var data = this._encodeTag(tagId, tagData);
+    if(this._stack.length > 0) {
+        this._stack[this._stack.length - 1].children.push({
+            data: data
+        });
+    } else {
+        this._bufferAndFlush(data.toBuffer());
+    }
 };
 
 EbmlEncoder.prototype.startTag = function(tagName) {
@@ -88,24 +105,26 @@ EbmlEncoder.prototype.startTag = function(tagName) {
 
     var tag = {
         id: tagId,
+        name: tagName,
         children: []
     };
-    this._stack[this._stack.length - 1].children.push(tag);
+
+    if(this._stack.length > 0) {
+        this._stack[this._stack.length - 1].children.push(tag);
+    }
     this._stack.push(tag);
 };
 
-EbmlEncoder.prototype.endTag = function() {
-
-    var tag = this._stack[this._stack.length - 1];
+EbmlEncoder.prototype.endTag = function(tagName) {
+    var tag = this._stack.pop();
 
     var childTagDataBuffers = tag.children.map(function(child) {
         return child.data;
     });
     tag.data = this._encodeTag(tag.id, Buffers(childTagDataBuffers));
-    this._stack.pop();
 
-    if (this._stack.length === 1) {
-        this._flush();
+    if (this._stack.length < 1) {
+        this._bufferAndFlush(tag.data.toBuffer());
     }
 };
 

--- a/test/decoder.js
+++ b/test/decoder.js
@@ -66,7 +66,10 @@ describe('embl', function() {
 
         it('should emit correct tag events for simple data', function(done) {
             var decoder = new ebml.Decoder();
-            decoder.on('EBMLVersion', function(data) {
+            decoder.on('data', function(data) {
+                var state = data[0];
+                data = data[1];
+                assert.equal(state, 'tag');
                 assert.equal(data.tag, 0x286);
                 assert.equal(data.tagStr, "4286");
                 assert.equal(data.dataSize, 0x01);
@@ -80,7 +83,10 @@ describe('embl', function() {
         it('should emit correct EBML tag events for master tags', function(done) {
             var decoder = new ebml.Decoder();
 
-            decoder.on('EBML', function(data) {
+            decoder.on('data', function(data) {
+                var state = data[0];
+                data = data[1];
+                assert.equal(state, 'start');
                 assert.equal(data.tag, 0x0a45dfa3);
                 assert.equal(data.tagStr, "1a45dfa3");
                 assert.equal(data.dataSize, 0);
@@ -95,20 +101,20 @@ describe('embl', function() {
         it('should emit correct EBML:end events for master tags', function(done) {
             var decoder = new ebml.Decoder();
             var tags = 0;
-            decoder.on('EBML', function(data) {
-                tags++;
-            });
-            decoder.on('EBMLVersion', function(data) {
-                tags++;
-            });
-            decoder.on('EBML:end', function(data) {
-                assert.equal(tags, 2); // two tags
-                assert.equal(data.tag, 0x0a45dfa3);
-                assert.equal(data.tagStr, "1a45dfa3");
-                assert.equal(data.dataSize, 4);
-                assert.equal(data.type, 'm');
-                assert.equal(data.data, undefined);
-                done();
+            decoder.on('data', function(data) {
+                var state = data[0];
+                data = data[1];
+                if(state != 'end') {
+                    tags++;
+                } else {
+                    assert.equal(tags, 2); // two tags
+                    assert.equal(data.tag, 0x0a45dfa3);
+                    assert.equal(data.tagStr, "1a45dfa3");
+                    assert.equal(data.dataSize, 4);
+                    assert.equal(data.type, 'm');
+                    assert.equal(data.data, undefined);
+                    done();
+                }
             });
             decoder.write(new Buffer([0x1a, 0x45, 0xdf, 0xa3]));
             decoder.write(new Buffer([0x84, 0x42, 0x86, 0x81, 0x00]));

--- a/test/encoder.js
+++ b/test/encoder.js
@@ -13,13 +13,23 @@ describe('embl', function() {
         }
         it('should write a single tag', function(done) {
             var encoder = createEncoder([0x42, 0x86, 0x81, 0x01], done);
-            encoder.writeTag('EBMLVersion', new Buffer([0x01]));
+            encoder.write(['tag', {
+                name: 'EBMLVersion',
+                data: new Buffer([0x01])
+            }]);
         });
         it('should write a tag with a single child', function(done) {
             var encoder = createEncoder([0x1a, 0x45, 0xdf, 0xa3, 0x84, 0x42, 0x86, 0x81, 0x00], done);
-            encoder.startTag('EBML');
-            encoder.writeTag('EBMLVersion', new Buffer([0x00]));
-            encoder.endTag();
+            encoder.write(['start', {
+                name: 'EBML',
+            }]);
+            encoder.write(['tag', {
+                name: 'EBMLVersion',
+                data: new Buffer([0x00])
+            }]);
+            encoder.write(['end', {
+                name: 'EBML',
+            }]);
         });
     });
 });

--- a/test/pipeline.js
+++ b/test/pipeline.js
@@ -1,0 +1,18 @@
+var ebml = require('../lib/ebml/index.js'),
+    assert = require('assert');
+
+describe('embl', function() {
+    describe('Pipeline', function() {
+        it('should output input buffer', function(done) {
+            var decoder = new ebml.Decoder();
+            var encoder = new ebml.Encoder();
+            var buffer = new Buffer([0x1a, 0x45, 0xdf, 0xa3, 0x84, 0x42, 0x86, 0x81, 0x00]);
+            encoder.on('data', function(chunk) {
+                assert.equal(chunk.toString('hex'), buffer.toString('hex'));
+                done();
+            });
+            decoder.pipe(encoder);
+            decoder.write(buffer);
+        });
+    });
+});


### PR DESCRIPTION
We converted the decoder and encoder into transform streams. This allows us to use them as input / output of a pipeline. Within the pipeline it is much easier to deal with the parsed data to monitor or modify it.