### PR TITLE
change length descriptor according to specification

### DIFF
--- a/lib/ebml/tools.js
+++ b/lib/ebml/tools.js
@@ -37,7 +37,7 @@ var tools = {
             throw new Error("Unrepresentable value: " + value);
         }
         for (var length = 1; length <= 8; length++) {
-            if (value < Math.pow(2, 7 * length)) {
+            if (value < Math.pow(2, 7 * length) - 1) {
                 break;
             }
         }

--- a/test/ebml.js
+++ b/test/ebml.js
@@ -80,36 +80,36 @@ describe('embl', function() {
                 }, /Unrepresentable value/);
             });
             it('should write all 1 byte ints', function() {
-                for (var i = 0; i < 0x80; i++) {
+                for (var i = 0; i < 0x80 - 1; i++) {
                     writeVint(i, new Buffer([i | 0x80]));
                 }
             });
             it('should write 2 byte int min/max values', function() {
-                writeVint(Math.pow(2, 7), new Buffer([0x40, 0x80]));
-                writeVint(Math.pow(2, 14) - 1, new Buffer([0x7F, 0xFF]));
+                writeVint(Math.pow(2, 7) - 1, new Buffer([0x40, 0x7F]));
+                writeVint(Math.pow(2, 14) - 2, new Buffer([0x7F, 0xFE]));
             });
             it('should write 3 byte int min/max values', function() {
-                writeVint(Math.pow(2, 14), new Buffer([0x20, 0x40, 0x00]));
-                writeVint(Math.pow(2, 21) - 1, new Buffer([0x3F, 0xFF, 0xFF]));
+                writeVint(Math.pow(2, 14) - 1, new Buffer([0x20, 0x3F, 0xFF]));
+                writeVint(Math.pow(2, 21) - 2, new Buffer([0x3F, 0xFF, 0xFE]));
             });
             it('should write 4 byte int min/max values', function() {
-                writeVint(Math.pow(2, 21), new Buffer([0x10, 0x20, 0x00, 0x00]));
-                writeVint(Math.pow(2, 28) - 1, new Buffer([0x1F, 0xFF, 0xFF, 0xFF]));
+                writeVint(Math.pow(2, 21) - 1, new Buffer([0x10, 0x1F, 0xFF, 0xFF]));
+                writeVint(Math.pow(2, 28) - 2, new Buffer([0x1F, 0xFF, 0xFF, 0xFE]));
             });
             it('should write 5 byte int min/max value', function() {
-                writeVint(Math.pow(2, 28), new Buffer([0x08, 0x10, 0x00, 0x00, 0x00]));
-                writeVint(Math.pow(2, 35) - 1, new Buffer([0x0F, 0xFF, 0xFF, 0xFF, 0xFF]));
+                writeVint(Math.pow(2, 28) - 1, new Buffer([0x08, 0x0F, 0xFF, 0xFF, 0xFF]));
+                writeVint(Math.pow(2, 35) - 2, new Buffer([0x0F, 0xFF, 0xFF, 0xFF, 0xFE]));
             });
             it('should write 6 byte int min/max value', function() {
-                writeVint(Math.pow(2, 35), new Buffer([0x04, 0x08, 0x00, 0x00, 0x00, 0x00]));
-                writeVint(Math.pow(2, 42) - 1, new Buffer([0x07, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]));
+                writeVint(Math.pow(2, 35) - 1, new Buffer([0x04, 0x07, 0xFF, 0xFF, 0xFF, 0xFF]));
+                writeVint(Math.pow(2, 42) - 2, new Buffer([0x07, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE]));
             });
             it('should write 7 byte int min/max value', function() {
-                writeVint(Math.pow(2, 42), new Buffer([0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00]));
-                writeVint(Math.pow(2, 49) - 1, new Buffer([0x03, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]));
+                writeVint(Math.pow(2, 42) - 1, new Buffer([0x02, 0x03, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]));
+                writeVint(Math.pow(2, 49) - 2, new Buffer([0x03, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE]));
             });
             it('should write the correct value for 8 byte int min value', function() {
-                writeVint(Math.pow(2, 49), new Buffer([0x01, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]));
+                writeVint(Math.pow(2, 49) - 1, new Buffer([0x01, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]));
             });
             it('should write the correct value for the max representable JS number (2^53)', function() {
                 writeVint(Math.pow(2, 53), new Buffer([0x01, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]));


### PR DESCRIPTION
According to Matroska specification (http://www.matroska.org/technical/specs/index.html) "Any ID where all x's are composed entirely of 1's is a Reserved ID". Given a length l the valid range of values is 0 to  2^(7 * l)-2. Previous implementation caused corruption of blocks with data length 127, 16383, ..., 2^(7 * l)-1.

I noticed this because streams got eventually corrupted. The browser stopped decoding with MEDIA_ERR_DECODE. chrome://media-internals/ only stated that decoding the data has failed. Recording the stream into a file and processing it with ffmpeg gave

[matroska,webm @ 0x718560] Invalid length 0xffffffffffffff > 0x10000000 for syntax element 5

with a few frames dropped. Tracking it down which frames were dropped it appeared that there was a SimpleBlock with data length of 127 bytes. The remaining SimpleBlock's of that Cluster were dropped and processing continued on the next healthy cluster. After fixing the bug and re-encoding the same (corrput) webm file all frames were processed fine.