### PR TITLE
fix(decoder): close unknown-sized elements lazily

### DIFF
--- a/lib/ebml/decoder.js
+++ b/lib/ebml/decoder.js
@@ -160,7 +160,7 @@ EbmlDecoder.prototype.readContent = function() {
 
     while (this._tag_stack.length > 0) {
         var topEle = this._tag_stack[this._tag_stack.length - 1];
-        if (this._total < topEle.end) {
+        if (topEle.end < 0 || this._total < topEle.end) {
             break;
         }
         this.push(['end', topEle]);
@@ -169,6 +169,13 @@ EbmlDecoder.prototype.readContent = function() {
 
     debug('read data: ' + data.toString('hex'));
     return true;
+};
+
+EbmlDecoder.prototype._flush = function() {
+  while (this._tag_stack.length) {
+    var el = this._tag_stack.pop();
+    this.push(['end', el]);
+  }
 };
 
 module.exports = EbmlDecoder;


### PR DESCRIPTION
I think unknown sized elements should be closed lazily instead. At least that seems to be the semantic used in the wild.