### PR TITLE
support end === -1 on re-encode

### DIFF
--- a/lib/ebml/encoder.js
+++ b/lib/ebml/encoder.js
@@ -22,7 +22,7 @@ EbmlEncoder.prototype._transform = function(chunk, enc, done) {
     debug('encode ' + chunk[0] + ' ' + chunk[1].name);
 
     if(chunk[0] === 'start') {
-        this.startTag(chunk[1].name);
+        this.startTag(chunk[1].name, chunk[1]);
     } else if(chunk[0] === 'tag') {
         this.writeTag(chunk[1].name, chunk[1].data);
     } else if(chunk[0] === 'end') {
@@ -77,8 +77,8 @@ EbmlEncoder.prototype.uncork = function() {
     this._flush();
 };
 
-EbmlEncoder.prototype._encodeTag = function(tagId, tagData) {
-    return Buffers([tagId, tools.writeVint(tagData.length), tagData]);
+EbmlEncoder.prototype._encodeTag = function(tagId, tagData, end) {
+    return Buffers([tagId, end === -1 ? Buffer('01ffffffffffffff', 'hex') : tools.writeVint(tagData.length), tagData]);
 };
 
 EbmlEncoder.prototype.writeTag = function(tagName, tagData) {
@@ -97,7 +97,7 @@ EbmlEncoder.prototype.writeTag = function(tagName, tagData) {
     }
 };
 
-EbmlEncoder.prototype.startTag = function(tagName) {
+EbmlEncoder.prototype.startTag = function(tagName, info) {
     var tagId = this.getSchemaInfo(tagName);
     if (!tagId) {
         throw new Error('No schema entry found for ' + tagName);
@@ -106,6 +106,7 @@ EbmlEncoder.prototype.startTag = function(tagName) {
     var tag = {
         id: tagId,
         name: tagName,
+        end: info.end,
         children: []
     };
 
@@ -121,7 +122,7 @@ EbmlEncoder.prototype.endTag = function(tagName) {
     var childTagDataBuffers = tag.children.map(function(child) {
         return child.data;
     });
-    tag.data = this._encodeTag(tag.id, Buffers(childTagDataBuffers));
+    tag.data = this._encodeTag(tag.id, Buffers(childTagDataBuffers), tag.end);
 
     if (this._stack.length < 1) {
         this._bufferAndFlush(tag.data.toBuffer());

--- a/test/pipeline.js
+++ b/test/pipeline.js
@@ -14,5 +14,20 @@ describe('embl', function() {
             decoder.pipe(encoder);
             decoder.write(buffer);
         });
+
+        it('should support end === -1', function (done) {
+            var decoder = new ebml.Decoder();
+            var encoder = new ebml.Encoder();
+
+            encoder.write(['start', {name: 'Cluster', start: 0, end: -1}]);
+            encoder.write(['end', {name: 'Cluster', start: 0, end: -1}]);
+
+            encoder.pipe(decoder).on('data', function (data) {
+                assert.equal(data[1].name, 'Cluster');
+                assert.equal(data[1].start, 0);
+                assert.equal(data[1].end, -1);
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
this fixes an issue where the length would be set to an invalid number when re-encoding live streaming webm files.