### PR TITLE
improve decoder performance on browserify

### DIFF
--- a/lib/ebml/decoder.js
+++ b/lib/ebml/decoder.js
@@ -167,7 +167,9 @@ EbmlDecoder.prototype.readContent = function() {
         this._tag_stack.pop();
     }
 
-    debug('read data: ' + data.toString('hex'));
+    if (debug.enabled) {
+        debug('read data: ' + data.toString('hex'));
+    }
     return true;
 };
 


### PR DESCRIPTION
data.toString('hex') is extremely expensive for large buffers
when used with browserify, so it should only be called if debug
is enabled.